### PR TITLE
Adds android-studio to android opt-in

### DIFF
--- a/scripts/opt-in/android.sh
+++ b/scripts/opt-in/android.sh
@@ -4,5 +4,6 @@ set +e
 brew tap AdoptOpenJDK/openjdk
 brew_cask_install_if_missing adoptopenjdk8
 brew_cask_install_if_missing android-sdk
+brew_cask_install_if_missing android-studio
 
 set -e

--- a/single.sh
+++ b/single.sh
@@ -12,6 +12,7 @@ set -e
 MY_DIR="$(dirname "$0")"
 
 source ${MY_DIR}/env.sh
+source ${MY_DIR}/scripts/helpers/brew.sh
 
 for filename in "$@"
 do


### PR DESCRIPTION
This change will install Android Studio along with the other opt-in items for Android. A small change was made to `single.sh` to include the `brew_install_if_missing_helper`